### PR TITLE
Update github actions to fix deprecation warning.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build Python source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.9'
       - name: Build sdist
         run: python setup.py sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: source
           path: dist/*.tar.gz
@@ -46,7 +46,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip setuptools wheel pytest
       - name: Download source distribution
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: source
       - name: Get package name
@@ -74,7 +74,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Download source distribution
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: source
       - name: Get package name
@@ -91,7 +91,7 @@ jobs:
           CIBW_BUILD: "pp39-*"
           CIBW_BEFORE_BUILD_LINUX: pip install cmake
           CIBW_BUILD_VERBOSITY: 1
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -101,21 +101,21 @@ jobs:
     name: Upload Python distribution to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: source
           path: dist
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release' && !github.event.release.prerelease
         with:
           user: __token__


### PR DESCRIPTION
Update deprecated github actions and switch pypi-publish to `v1` since `master` now throws a "sunsetted" error message.